### PR TITLE
Fix typo in english version “in sock” -> “in stock”

### DIFF
--- a/polybookexchange/locale/fr/LC_MESSAGES/django.po
+++ b/polybookexchange/locale/fr/LC_MESSAGES/django.po
@@ -1255,7 +1255,7 @@ msgstr "Statistiques"
 
 #: templates/polybookexchange/templatetags/show_book.html:30
 #, python-format
-msgid "%(sold)s book%(p)s sold, %(stock)s in sock"
+msgid "%(sold)s book%(p)s sold, %(stock)s in stock"
 msgstr "%(sold)s livre%(p)s vendus, %(stock)s en stock"
 
 #: templates/polybookexchange/templatetags/show_book.html:32

--- a/polybookexchange/templates/polybookexchange/templatetags/show_book.html
+++ b/polybookexchange/templates/polybookexchange/templatetags/show_book.html
@@ -27,7 +27,7 @@
         <dd>{{ book.avg_price|floatformat:2 }}</dd>
 
         <dt>{% trans "Stats" %}</dt>
-        <dd>{% blocktrans with p=book.qty_sold|pluralize sold=book.qty_sold stock=book.qty_in_stock %}{{sold}} book{{p}} sold, {{stock}} in sock{% endblocktrans %}</dd>
+        <dd>{% blocktrans with p=book.qty_sold|pluralize sold=book.qty_sold stock=book.qty_in_stock %}{{sold}} book{{p}} sold, {{stock}} in stock{% endblocktrans %}</dd>
 
         {% if show_details %}<a href="{% url 'polybookexchange.views.book' book.isbn %}" class="btn btn-primary pull-right"><i class="glyphicon glyphicon-briefcase"></i> {% trans "More details" %}</a><br />{% endif %}
     </dl>


### PR DESCRIPTION
Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>